### PR TITLE
Fix 8 code review findings across security, bugs, and consistency

### DIFF
--- a/.claude/skills/shelli/SKILL.md
+++ b/.claude/skills/shelli/SKILL.md
@@ -162,6 +162,7 @@ Other flags:
 - `--timeout N`: Max wait time (default: 10s)
 - `--strip-ansi`: Remove ANSI escape codes
 - `--json`: Output as JSON
+- `--cursor "name"`: Named cursor for per-consumer read tracking. Each cursor maintains its own position.
 
 Examples:
 ```bash
@@ -541,6 +542,7 @@ shelli create session --cmd "command"
 - **Output buffering**: All output is buffered with position tracking
 - **Socket communication**: CLI talks to daemon via Unix socket (`~/.shelli/shelli.sock`)
 - **Max output**: Default 10MB buffer per session (configurable via daemon `--max-output`)
+- **Per-consumer cursors**: `--cursor` flag (or MCP `cursor` param) allows multiple consumers to independently track read positions on the same session
 
 ## Limitations
 

--- a/README.md
+++ b/README.md
@@ -222,11 +222,13 @@ shelli read <name> [flags]
 **Blocking modes** (returns new output):
 - `--wait "pattern"` - Wait for regex pattern match
 - `--settle N` - Wait for N ms of silence
+- `--head N` / `--tail N` - Limit output lines (applied after wait/settle completes)
 
 Other flags:
 - `--timeout N` - Max wait time in seconds (default: 10)
 - `--settle N` - Override default settle time (300ms for snapshot, used with --wait/--settle modes)
 - `--strip-ansi` - Remove terminal escape codes
+- `--cursor "name"` - Named cursor for per-consumer read tracking
 - `--json` - Output as JSON
 
 Examples:
@@ -356,11 +358,11 @@ Sessions have explicit states with clear transitions:
 
 ## Storage
 
-By default, shelli stores session output in files at `/tmp/shelli/`:
+By default, shelli stores session output in files at `~/.shelli/data/`:
 
 ```
-/tmp/shelli/
-├── mysession.out    # raw PTY output
+~/.shelli/data/
+├── mysession.out    # raw PTY output (0600 permissions)
 └── mysession.meta   # JSON metadata (state, pid, timestamps)
 ```
 
@@ -377,7 +379,7 @@ shelli daemon [flags]
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--data-dir` | `/tmp/shelli` | Directory for session files |
+| `--data-dir` | `~/.shelli/data` | Directory for session files |
 | `--memory-backend` | `false` | Use in-memory storage (no persistence) |
 | `--stopped-ttl` | (disabled) | Auto-delete stopped sessions after duration |
 | `--max-output` | `10MB` | Buffer size limit (memory backend only) |

--- a/cmd/daemon.go
+++ b/cmd/daemon.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
@@ -35,8 +36,8 @@ func init() {
 		"Maximum output buffer size per session for memory backend (e.g., 10MB, 1GB)")
 	daemonCmd.Flags().BoolVar(&daemonMCPFlag, "mcp", false,
 		"Run as MCP server (JSON-RPC over stdio)")
-	daemonCmd.Flags().StringVar(&daemonDataDirFlag, "data-dir", "/tmp/shelli",
-		"Directory for session output files (file backend only)")
+	daemonCmd.Flags().StringVar(&daemonDataDirFlag, "data-dir", "",
+		"Directory for session output files (default: ~/.shelli/data)")
 	daemonCmd.Flags().BoolVar(&daemonMemoryBackend, "memory-backend", false,
 		"Use in-memory storage instead of file-based (no persistence)")
 	daemonCmd.Flags().StringVar(&daemonStoppedTTLFlag, "stopped-ttl", "",
@@ -49,6 +50,14 @@ func runDaemon(cmd *cobra.Command, args []string) error {
 	}
 
 	var opts []daemon.ServerOption
+
+	if daemonDataDirFlag == "" {
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			return fmt.Errorf("get home dir: %w", err)
+		}
+		daemonDataDirFlag = filepath.Join(homeDir, ".shelli", "data")
+	}
 
 	if daemonMemoryBackend {
 		maxSize, err := parseSize(daemonMaxOutputFlag)

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -86,6 +86,7 @@ func runExec(cmd *cobra.Command, args []string) error {
 			SettleMs:      settleMs,
 			TimeoutSec:    execTimeoutFlag,
 			StartPosition: startPos,
+			SizeFunc:      func() (int, error) { return client.Size(name) },
 		},
 	)
 	if err != nil {

--- a/internal/daemon/limitlines_test.go
+++ b/internal/daemon/limitlines_test.go
@@ -19,9 +19,9 @@ func TestLimitLines(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := limitLines(tt.input, tt.head, tt.tail)
+			got := LimitLines(tt.input, tt.head, tt.tail)
 			if got != tt.expect {
-				t.Errorf("limitLines(%q, %d, %d) = %q, want %q", tt.input, tt.head, tt.tail, got, tt.expect)
+				t.Errorf("LimitLines(%q, %d, %d) = %q, want %q", tt.input, tt.head, tt.tail, got, tt.expect)
 			}
 		})
 	}

--- a/internal/daemon/storage.go
+++ b/internal/daemon/storage.go
@@ -16,8 +16,9 @@ type SessionMeta struct {
 	State     SessionState `json:"state"`
 	CreatedAt time.Time    `json:"created_at"`
 	StoppedAt *time.Time   `json:"stopped_at,omitempty"`
-	ReadPos   int64        `json:"read_pos"`
-	Cols      int          `json:"cols"`
+	ReadPos   int64            `json:"read_pos"`
+	Cursors   map[string]int64 `json:"cursors,omitempty"`
+	Cols      int              `json:"cols"`
 	Rows      int          `json:"rows"`
 	TUIMode   bool         `json:"tui_mode,omitempty"`
 }

--- a/internal/daemon/storage_memory.go
+++ b/internal/daemon/storage_memory.go
@@ -33,8 +33,13 @@ func (s *MemoryStorage) Append(session string, data []byte) error {
 	if s.maxOutputSize > 0 && len(s.outputs[session]) > s.maxOutputSize {
 		excess := len(s.outputs[session]) - s.maxOutputSize
 		s.outputs[session] = s.outputs[session][excess:]
-		if meta, ok := s.metas[session]; ok && meta.ReadPos > 0 {
-			meta.ReadPos = max(0, meta.ReadPos-int64(excess))
+		if meta, ok := s.metas[session]; ok {
+			if meta.ReadPos > 0 {
+				meta.ReadPos = max(0, meta.ReadPos-int64(excess))
+			}
+			for k, v := range meta.Cursors {
+				meta.Cursors[k] = max(0, v-int64(excess))
+			}
 		}
 	}
 
@@ -89,6 +94,7 @@ func (s *MemoryStorage) Clear(session string) error {
 	s.outputs[session] = []byte{}
 	if meta, ok := s.metas[session]; ok {
 		meta.ReadPos = 0
+		meta.Cursors = nil
 	}
 	return nil
 }


### PR DESCRIPTION
## Bug Fix

Deep code review identified 8 validated issues in shelli: two active bugs, three behavioral inconsistencies between CLI and MCP, one security default problem, one performance issue, and one concurrency correctness fix. All are resolved in this PR.

## Solution

Session output files now use restrictive permissions (0700 directories, 0600 files) with a secure default data directory at `~/.shelli/data`. The daemon shutdown path uses `sync.Once` and `atomic.Bool` to prevent listener races and double-close panics. All process termination paths call `cmd.Wait()` to reap zombie processes. Blocking reads with `--head`/`--tail` defer line truncation until after the wait loop completes, fixing pattern match timeouts. A new lightweight `size` endpoint enables poll-loop optimization by skipping full buffer reads when nothing changed. Per-consumer read cursors allow multiple agents to independently tail the same session.

## Changes

**Security** (`storage_file.go`, `server.go`, `daemon.go`):
- File/directory permissions tightened to 0600/0700
- Default data directory moved from `/tmp/shelli` to `~/.shelli/data`

**Concurrency** (`server.go`):
- Shutdown wrapped in `sync.Once` with `atomic.Bool` for listener check
- `cmd.Wait()` added in stop, kill, and shutdown to prevent zombie processes

**CLI/MCP consistency** (`tools.go`, `read.go`):
- MCP read validates `wait_pattern` + `settle_ms` mutual exclusivity
- MCP blocking read advances the read cursor (matches CLI behavior)
- Blocking read with head/tail defers truncation after wait completes

**Performance** (`wait.go`, `server.go`, `client.go`):
- `SizeFunc` in wait polling skips full reads when buffer size unchanged
- New `size` daemon action returns buffer size without content transfer

**Feature** (`storage.go`, `server.go`, `client.go`, `read.go`, `tools.go`):
- Per-consumer read cursors via `--cursor` flag (CLI) and `cursor` param (MCP)
- Each named cursor tracks its own position independently
- Cursors adjusted on circular buffer trim and reset on clear