### PR TITLE
Fix 4 critical correctness bugs in daemon server

### DIFF
--- a/cmd/search.go
+++ b/cmd/search.go
@@ -52,6 +52,10 @@ func runSearch(cmd *cobra.Command, args []string) error {
 		after = searchAroundFlag
 	}
 
+	if before < 0 || after < 0 {
+		return fmt.Errorf("--before, --after, and --around must be non-negative")
+	}
+
 	client := daemon.NewClient()
 	if err := client.EnsureDaemon(); err != nil {
 		return fmt.Errorf("daemon: %w", err)

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -831,6 +831,10 @@ func (r *ToolRegistry) callSearch(args json.RawMessage) (*CallToolResult, error)
 		after = a.Around
 	}
 
+	if before < 0 || after < 0 {
+		return nil, fmt.Errorf("before, after, and around must be non-negative")
+	}
+
 	resp, err := r.client.Search(daemon.SearchRequest{
 		Name:       a.Name,
 		Pattern:    a.Pattern,


### PR DESCRIPTION
## Bug

The daemon server has four correctness bugs that can cause crashes, hangs, or undefined behavior under normal operation. Negative search context values panic the daemon (DoS vector for any client including MCP agents). The kill handler blocks the entire daemon under mutex while waiting for process death. Multiple code paths can double-close PTY file descriptors. A data race exists on `s.listener` between `Start()` and `Shutdown()`.

## Solution

All four issues are fixed with minimal, targeted changes. Input validation rejects negative `before`/`after` values at three boundaries (server, CLI, MCP). The kill handler releases the mutex before async process cleanup, mirroring the existing `handleStop` pattern. A `ptyHandle` wrapper with `sync.Once` guarantees each PTY fd is closed exactly once regardless of which code path runs first. The listener nil-check in `Start()` now runs under the mutex to match `Shutdown()`.

## Changes

**Search validation** (`server.go`, `cmd/search.go`, `internal/mcp/tools.go`):
- Server rejects `before < 0 || after < 0` before touching any state
- CLI validates after `--around` expansion
- MCP validates after `around` expansion

**Kill handler** (`server.go`):
- `handleKill` captures process reference under lock, releases lock, then spawns goroutine for SIGTERM/SIGKILL/Wait

**PTY double-close** (`server.go`):
- New `ptyHandle` type wraps `*os.File` with `sync.Once` close
- `s.ptys` map stores `*ptyHandle` instead of `*os.File`
- All PTY consumers (`captureOutput`, `handleStop`, `handleKill`, `Shutdown`, `handleSnapshot`, `handleSend`, `handleResize`) use the handle

**Listener race** (`server.go`):
- `s.listener == nil` check in `Start()` accept loop now holds `s.mu`