### PR TITLE
Phase 4: Usability & interface improvements

### DIFF
--- a/.claude/skills/shelli-auto-detector/SKILL.md
+++ b/.claude/skills/shelli-auto-detector/SKILL.md
@@ -209,8 +209,8 @@ shelli read openclaw --strip-ansi
 | `npm test` | Bash | Exits with status |
 | `npm run dev` + "watch for errors" | shelli | Long-running |
 | `openclaw tui` | shelli | TUI with two-step submit |
-| `vim file.txt` | Bash (not shelli) | Full-screen TUI, use `sed`/`Edit` |
-| `htop` | Bash (not shelli) | Full-screen TUI, use `ps aux` |
+| `vim file.txt` | shelli (--tui) | Full-screen TUI, use TUI mode with snapshot |
+| `htop` | shelli (--tui) | Full-screen TUI, use TUI mode with snapshot |
 
 ## Proactive Suggestions
 

--- a/README.md
+++ b/README.md
@@ -398,7 +398,7 @@ shelli daemon --stopped-ttl 1h
 
 ## Escape Sequences
 
-When using `send --raw`, escape sequences are interpreted:
+When using `send`, escape sequences are always interpreted:
 
 | Sequence | Character | Description |
 |----------|-----------|-------------|
@@ -425,16 +425,16 @@ When using `send --raw`, escape sequences are interpreted:
 
 ```bash
 # Interrupt a long-running command
-shelli send myshell "\x03" --raw
+shelli send myshell "\x03"
 
 # Send EOF to close stdin
-shelli send myshell "\x04" --raw
+shelli send myshell "\x04"
 
 # Tab completion
-shelli send myshell "doc\t" --raw
+shelli send myshell "doc\t"
 
 # Answer a yes/no prompt without newline, then send newline
-shelli send myshell "y" --raw
+shelli send myshell "y"
 shelli send myshell ""              # just newline
 ```
 

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -16,13 +16,14 @@ var createCmd = &cobra.Command{
 }
 
 var (
-	createCmdFlag  string
-	createJsonFlag bool
-	createEnvFlag  []string
-	createCwdFlag  string
-	createColsFlag int
-	createRowsFlag int
-	createTUIFlag  bool
+	createCmdFlag         string
+	createJsonFlag        bool
+	createEnvFlag         []string
+	createCwdFlag         string
+	createColsFlag        int
+	createRowsFlag        int
+	createTUIFlag         bool
+	createIfNotExistsFlag bool
 )
 
 func init() {
@@ -33,6 +34,7 @@ func init() {
 	createCmd.Flags().IntVar(&createColsFlag, "cols", 80, "Terminal columns")
 	createCmd.Flags().IntVar(&createRowsFlag, "rows", 24, "Terminal rows")
 	createCmd.Flags().BoolVar(&createTUIFlag, "tui", false, "Enable TUI mode (auto-truncate buffer on frame boundaries)")
+	createCmd.Flags().BoolVar(&createIfNotExistsFlag, "if-not-exists", false, "Return existing session if already running instead of error")
 }
 
 func runCreate(cmd *cobra.Command, args []string) error {
@@ -44,12 +46,13 @@ func runCreate(cmd *cobra.Command, args []string) error {
 	}
 
 	data, err := client.Create(name, daemon.CreateOptions{
-		Command: createCmdFlag,
-		Env:     createEnvFlag,
-		Cwd:     createCwdFlag,
-		Cols:    createColsFlag,
-		Rows:    createRowsFlag,
-		TUIMode: createTUIFlag,
+		Command:     createCmdFlag,
+		Env:         createEnvFlag,
+		Cwd:         createCwdFlag,
+		Cols:        createColsFlag,
+		Rows:        createRowsFlag,
+		TUIMode:     createTUIFlag,
+		IfNotExists: createIfNotExistsFlag,
 	})
 	if err != nil {
 		return err

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/schovi/shelli/internal/ansi"
@@ -74,7 +75,10 @@ func runExec(cmd *cobra.Command, args []string) error {
 		TimeoutSec:  execTimeoutFlag,
 	})
 	if err != nil {
-		return err
+		if result == nil || result.Output == "" {
+			return err
+		}
+		fmt.Fprintf(os.Stderr, "Warning: %v\n", err)
 	}
 
 	output := result.Output

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -54,6 +54,12 @@ func runInfo(cmd *cobra.Command, args []string) error {
 		fmt.Printf("Buffer:  %d bytes\n", info.BytesBuffered)
 		fmt.Printf("ReadPos: %d\n", info.ReadPosition)
 		fmt.Printf("Size:    %dx%d\n", info.Cols, info.Rows)
+		if len(info.Cursors) > 0 {
+			fmt.Printf("Cursors:\n")
+			for name, pos := range info.Cursors {
+				fmt.Printf("  %s: %d\n", name, pos)
+			}
+		}
 	}
 	return nil
 }

--- a/cmd/kill.go
+++ b/cmd/kill.go
@@ -17,8 +17,13 @@ func init() {
 var killCmd = &cobra.Command{
 	Use:   "kill <name>",
 	Short: "Kill a session",
-	Args:  cobra.ExactArgs(1),
-	RunE:  runKill,
+	Long: `Kill a session: terminates the process (if running) and permanently deletes all stored output.
+
+To stop a session but keep output accessible for later reading, use 'stop' instead.
+
+This is a destructive operation and cannot be undone.`,
+	Args: cobra.ExactArgs(1),
+	RunE: runKill,
 }
 
 func runKill(cmd *cobra.Command, args []string) error {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -9,7 +9,14 @@ import (
 var rootCmd = &cobra.Command{
 	Use:   "shelli",
 	Short: "Shell Interactive - session manager for AI agents",
-	Long:  `shelli (Shell Interactive) enables AI agents to interact with persistent interactive shell sessions (REPLs, SSH, database CLIs, etc.)`,
+	Long: `shelli (Shell Interactive) enables AI agents to interact with persistent interactive shell sessions (REPLs, SSH, database CLIs, etc.)
+
+Quick start:
+  shelli create myshell                     # Start a shell session
+  shelli exec myshell "echo hello"          # Run command and get output
+  shelli read myshell                       # Read new output
+  shelli stop myshell                       # Stop (keeps output)
+  shelli kill myshell                       # Kill (deletes everything)`,
 }
 
 func Execute() {

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -95,13 +95,25 @@ func runSearch(cmd *cobra.Command, args []string) error {
 
 		startLine := match.LineNumber - len(match.Before)
 		for j, line := range match.Before {
-			fmt.Printf("%4d: %s\n", startLine+j, ansi.Strip(line))
+			display := line
+			if searchStripAnsiFlag {
+				display = ansi.Strip(line)
+			}
+			fmt.Printf("%4d: %s\n", startLine+j, display)
 		}
 
-		fmt.Printf(">%3d: %s\n", match.LineNumber, ansi.Strip(match.Line))
+		display := match.Line
+		if searchStripAnsiFlag {
+			display = ansi.Strip(match.Line)
+		}
+		fmt.Printf(">%3d: %s\n", match.LineNumber, display)
 
 		for j, line := range match.After {
-			fmt.Printf("%4d: %s\n", match.LineNumber+1+j, ansi.Strip(line))
+			display := line
+			if searchStripAnsiFlag {
+				display = ansi.Strip(line)
+			}
+			fmt.Printf("%4d: %s\n", match.LineNumber+1+j, display)
 		}
 	}
 

--- a/internal/daemon/storage_file.go
+++ b/internal/daemon/storage_file.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
-	"syscall"
 )
 
 type FileStorage struct {
@@ -40,11 +39,6 @@ func (s *FileStorage) Append(session string, data []byte) error {
 		return fmt.Errorf("open output file: %w", err)
 	}
 	defer f.Close()
-
-	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil { // #nosec G115 -- f.Fd() returns a valid file descriptor, overflow not possible
-		return fmt.Errorf("lock file: %w", err)
-	}
-	defer syscall.Flock(int(f.Fd()), syscall.LOCK_UN) // #nosec G115
 
 	if _, err := f.Write(data); err != nil {
 		return fmt.Errorf("write output: %w", err)

--- a/internal/daemon/storage_memory.go
+++ b/internal/daemon/storage_memory.go
@@ -138,6 +138,16 @@ func (s *MemoryStorage) LoadMeta(session string) (*SessionMeta, error) {
 		return nil, fmt.Errorf("session %q not found", session)
 	}
 	copied := *meta
+	if meta.Cursors != nil {
+		copied.Cursors = make(map[string]int64, len(meta.Cursors))
+		for k, v := range meta.Cursors {
+			copied.Cursors[k] = v
+		}
+	}
+	if meta.StoppedAt != nil {
+		t := *meta.StoppedAt
+		copied.StoppedAt = &t
+	}
 	return &copied, nil
 }
 


### PR DESCRIPTION
## Enhancement

Batch of 14 usability, correctness, and ergonomic improvements across CLI, MCP, and daemon. Follows the Phase 4 section of the consolidated code review plan.

## Solution

Each fix targets a specific UX gap or correctness issue. Changes are intentionally small and independent per item, touching the minimal surface area needed.

## Changes

**Timeout handling** (4.1):
- `exec` and `read` (both CLI and MCP) return partial output on timeout instead of discarding it
- MCP responses include a `warning` field alongside partial output

**Input validation** (4.2):
- `--cursor` is rejected when combined with `--snapshot` or `--follow` (CLI + MCP)
- Cursor-advance errors after blocking read are now propagated instead of silently ignored

**Info endpoint** (4.3):
- `info` response includes `cursors` map showing all named cursor positions

**Snapshot semantics** (4.4):
- Snapshot no longer updates global `ReadPos` (pure peek, no side effects on normal reads)

**Idempotent create** (4.5):
- New `--if-not-exists` flag (CLI) / `if_not_exists` parameter (MCP) returns existing running session instead of error

**List ordering** (4.6):
- `list` returns sessions sorted by creation time (oldest first) instead of random map order

**Error messages** (4.7):
- Daemon startup failure now includes socket path, timeout duration, and troubleshooting hints
- Detects stale socket scenario

**MCP settle semantics** (4.8):
- `settle_ms: 0` now means "don't wait" (previously treated as "use default 500ms")
- Uses `*int` to distinguish "not provided" from "explicitly zero"

**Kill help** (4.9):
- `kill` command help explains destructive behavior and suggests `stop` as alternative

**SocketPath error handling** (4.10):
- `SocketPath()` returns `(string, error)` instead of silently producing invalid path on `UserHomeDir` failure

**Memory storage correctness** (4.11):
- `LoadMeta` deep copies `Cursors` map and `StoppedAt` pointer to prevent shared mutation

**Search display** (4.12):
- Search output respects `--strip-ansi` flag for display (was unconditionally stripping)

**Documentation** (4.13):
- Removed stale `--raw` flag references from README (send always interprets escapes)
- Updated auto-detector skill to reflect TUI mode support for vim/htop

**FileStorage** (4.14):
- Removed redundant `syscall.Flock` from `Append` (Go mutex is sufficient for single-process daemon)

**Root help** (5.1):
- Added quick-start examples to `shelli --help`