### PR TITLE
Move runtime data from ~/.shelli to /tmp

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ shelli provides persistent interactive shell sessions via PTY-backed processes m
 - `storage_memory.go`: In-memory storage with circular buffer (default, 10MB limit)
 - `storage_file.go`: File-based persistent storage
 - `constants.go`: Shared constants (buffer sizes, timeouts)
-- Socket at `~/.shelli/shelli.sock`, auto-started on first command
+- Socket at `/tmp/shelli-{uid}/shelli.sock`, auto-started on first command
 
 **MCP Server** (`internal/mcp/`)
 - `server.go`: JSON-RPC stdio server implementing MCP protocol

--- a/README.md
+++ b/README.md
@@ -358,10 +358,10 @@ Sessions have explicit states with clear transitions:
 
 ## Storage
 
-By default, shelli stores session output in files at `~/.shelli/data/`:
+By default, shelli stores session output in files at `/tmp/shelli-{uid}/data/`:
 
 ```
-~/.shelli/data/
+/tmp/shelli-{uid}/data/
 ├── mysession.out    # raw PTY output (0600 permissions)
 └── mysession.meta   # JSON metadata (state, pid, timestamps)
 ```
@@ -379,7 +379,7 @@ shelli daemon [flags]
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--data-dir` | `~/.shelli/data` | Directory for session files |
+| `--data-dir` | `/tmp/shelli-{uid}/data` | Directory for session files |
 | `--memory-backend` | `false` | Use in-memory storage (no persistence) |
 | `--stopped-ttl` | (disabled) | Auto-delete stopped sessions after duration |
 | `--max-output` | `10MB` | Buffer size limit (memory backend only) |
@@ -387,7 +387,7 @@ shelli daemon [flags]
 Examples:
 ```bash
 # Use custom storage location
-shelli daemon --data-dir ~/.shelli/sessions
+shelli daemon --data-dir /tmp/shelli-sessions
 
 # Memory-only mode (v0.3 behavior)
 shelli daemon --memory-backend --max-output 50MB
@@ -454,7 +454,7 @@ shelli uses a daemon process to maintain PTY handles across CLI invocations:
 │                                                                      │
 │  ┌────────────────────┐      ┌────────────────────────────────┐    │
 │  │ MCP Server         │      │ Socket Server                  │    │
-│  │ (--mcp flag)       │      │ (~/.shelli/shelli.sock)        │    │
+│  │ (--mcp flag)       │      │ (/tmp/shelli-{uid}/shelli.sock)│    │
 │  └─────────┬──────────┘      └─────────────┬──────────────────┘    │
 │            └───────────┬───────────────────┘                        │
 │                        ▼                                            │

--- a/cmd/daemon.go
+++ b/cmd/daemon.go
@@ -39,7 +39,7 @@ func init() {
 	daemonCmd.Flags().BoolVar(&daemonMCPFlag, "mcp", false,
 		"Run as MCP server (JSON-RPC over stdio)")
 	daemonCmd.Flags().StringVar(&daemonDataDirFlag, "data-dir", "",
-		"Directory for session output files (default: ~/.shelli/data)")
+		"Directory for session output files (default: /tmp/shelli-{uid}/data)")
 	daemonCmd.Flags().BoolVar(&daemonMemoryBackend, "memory-backend", false,
 		"Use in-memory storage instead of file-based (no persistence)")
 	daemonCmd.Flags().StringVar(&daemonStoppedTTLFlag, "stopped-ttl", "",
@@ -68,11 +68,11 @@ func runDaemon(cmd *cobra.Command, args []string) error {
 	var opts []daemon.ServerOption
 
 	if daemonDataDirFlag == "" {
-		homeDir, err := os.UserHomeDir()
+		runtimeDir, err := daemon.RuntimeDir()
 		if err != nil {
-			return fmt.Errorf("get home dir: %w", err)
+			return fmt.Errorf("get runtime dir: %w", err)
 		}
-		daemonDataDirFlag = filepath.Join(homeDir, ".shelli", "data")
+		daemonDataDirFlag = filepath.Join(runtimeDir, "data")
 	}
 
 	if daemonMemoryBackend {


### PR DESCRIPTION
## Summary

- Move socket and session data from `~/.shelli/` to `/tmp/shelli-{uid}/`
- Sessions are ephemeral (PTY processes die on reboot), so `/tmp` is the natural location
- UID scoping prevents collisions on shared systems
- OS handles cleanup automatically

## Changes

- Add `RuntimeDir()` function returning `os.TempDir()/shelli-{uid}`
- Update `NewServer` and `SocketPath()` to use `RuntimeDir()`
- Update default `--data-dir` to `{RuntimeDir}/data`
- Update documentation (CLAUDE.md, README.md)

## Test plan

- [x] `go build .` passes
- [x] `go test -race ./...` passes
- [x] `make lint` passes (0 issues)
- [ ] Manual: `shelli create test -- echo hello && ls /tmp/shelli-$(id -u)/`