### PR TITLE
Fix flaky TestPerCursorReads via atomic meta updates

### DIFF
--- a/internal/daemon/storage.go
+++ b/internal/daemon/storage.go
@@ -36,5 +36,6 @@ type OutputStorage interface {
 
 	LoadMeta(session string) (*SessionMeta, error)
 	SaveMeta(session string, meta *SessionMeta) error
+	UpdateMeta(session string, fn func(meta *SessionMeta)) error
 	ListSessions() ([]string, error)
 }

--- a/internal/daemon/storage_file.go
+++ b/internal/daemon/storage_file.go
@@ -207,6 +207,18 @@ func (s *FileStorage) saveMetaLocked(session string, meta *SessionMeta) error {
 	return nil
 }
 
+func (s *FileStorage) UpdateMeta(session string, fn func(meta *SessionMeta)) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	meta, err := s.loadMetaLocked(session)
+	if err != nil {
+		return err
+	}
+	fn(meta)
+	return s.saveMetaLocked(session, meta)
+}
+
 func (s *FileStorage) ListSessions() ([]string, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()

--- a/internal/daemon/storage_memory.go
+++ b/internal/daemon/storage_memory.go
@@ -162,6 +162,18 @@ func (s *MemoryStorage) SaveMeta(session string, meta *SessionMeta) error {
 	return nil
 }
 
+func (s *MemoryStorage) UpdateMeta(session string, fn func(meta *SessionMeta)) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	meta, exists := s.metas[session]
+	if !exists {
+		return fmt.Errorf("session %q not found", session)
+	}
+	fn(meta)
+	return nil
+}
+
 func (s *MemoryStorage) ListSessions() ([]string, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()


### PR DESCRIPTION
## Bug

`TestPerCursorReads` fails intermittently on CI (Linux) because concurrent meta update paths can overwrite each other's changes. When `captureOutput` cleanup saves session state, it replaces the entire meta object, clobbering cursor positions that `handleRead` just wrote. The next read then starts from position 0 and returns duplicate content.

## Solution

An `UpdateMeta` method on the `OutputStorage` interface performs atomic read-modify-write under a single lock. Each call site only mutates the fields it owns (cursors, state, dimensions), so concurrent updates no longer overwrite unrelated fields.

## Changes

**Storage interface** (`storage.go`, `storage_memory.go`, `storage_file.go`):
- `UpdateMeta(session, func(meta))` added to interface and both implementations
- MemoryStorage mutates the stored meta in-place under write lock
- FileStorage loads, mutates, and saves back under write lock

**Server** (`server.go`):
- `captureOutput` cleanup, `handleStop`: use `UpdateMeta` for state transitions
- `handleRead`, `handleReadTUI`: use `UpdateMeta` for cursor/position updates
- `handleResize`: use `UpdateMeta` for dimension updates